### PR TITLE
[ISSUE #13][GENERAL] Add manual execution of the CI builds and fix issue with the Windows build

### DIFF
--- a/.github/workflows/build_clang_tidy.yml
+++ b/.github/workflows/build_clang_tidy.yml
@@ -5,6 +5,12 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Target branch'     
+        required: true
+        default: 'master'
 
 jobs:
   build_clang_tidy:

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -5,6 +5,12 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Target branch'     
+        required: true
+        default: 'master'
 
 jobs:
   build_linux:

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -5,6 +5,12 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Target branch'     
+        required: true
+        default: 'master'
 
 jobs:
   build_windows:
@@ -12,6 +18,8 @@ jobs:
     runs-on: windows-latest
 
     steps:
+
+    - uses: ilammy/msvc-dev-cmd@v1
          
     # Creation of the ..\downloads directory
     - name: Creation of the "..\downloads" directory
@@ -61,7 +69,6 @@ jobs:
     #CMake execution
     - name: CMake
       run: |
-        call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsx86_amd64.bat"
         cmake ..\${{ github.event.repository.name }}\dma_framework "-GCodeBlocks - NMake Makefiles JOM" "-DCMAKE_BUILD_TYPE:STRING=Release"
       shell: cmd
       working-directory: ..\build
@@ -69,7 +76,6 @@ jobs:
     # Build of the project
     - name: Jom
       run: |
-        call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsx86_amd64.bat"
         jom.exe -j8
       shell: cmd
       working-directory: ..\build
@@ -77,7 +83,6 @@ jobs:
     # Unit-tests execution
     - name: unit-tests
       run: | 
-        call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsx86_amd64.bat"
         ctest.exe --force-new-ctest-process .\
       shell: cmd
       working-directory: ../build


### PR DESCRIPTION
## [ISSUE #13][GENERAL] Add manual execution of the CI builds and fix issue with the Windows build

1. [x] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [x] Are all unit tests still pass successfully after your changes?

#### Change description:

- Added "workflow_dispatch" event to be able to start the builds manually
- Switched to the usage of the "ilammy/msvc-dev-cmd@v1" Git hub action

#### Verification criteria:

- CI build has finished successfully